### PR TITLE
feat: Implement Equipment State Pattern & Optimistic Locking

### DIFF
--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/EquipmentController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/EquipmentController.java
@@ -49,4 +49,16 @@ public class EquipmentController {
         equipmentService.deleteEquipment(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/{id}/reserve")
+    public ResponseEntity<?> reserveEquipment(@PathVariable Long id) {
+        try {
+            Equipment reserved = equipmentService.reserveEquipment(id);
+            return ResponseEntity.ok(reserved);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/Equipment.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/Equipment.java
@@ -1,9 +1,12 @@
 package com.lablend.backend.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 
 @Entity
 public class Equipment {
@@ -13,16 +16,41 @@ public class Equipment {
     private Long id;
     private String name;
     private String type;
-    private String status;
+    
+    @Enumerated(EnumType.STRING)
+    private EquipmentStatus status;
+
+    @Version
+    private Long version;
 
     public Equipment() {
     }
 
-    public Equipment(String name, String type, String status) {
+    public Equipment(String name, String type, EquipmentStatus status) {
         this.name = name;
         this.type = type;
         this.status = status;
     }
+
+
+    public void reserve() {
+        if (this.status != EquipmentStatus.AVAILABLE) {
+            throw new IllegalStateException("Solo se puede reservar equipo disponible. Estado actual: " + this.status);
+        }
+        this.status = EquipmentStatus.RESERVED;
+    }
+
+    public void startMaintenance() {
+        if (this.status == EquipmentStatus.RESERVED) {
+            throw new IllegalStateException("No se puede enviar a mantenimiento un equipo reservado.");
+        }
+        this.status = EquipmentStatus.UNDER_MAINTENANCE;
+    }
+
+    public void finishMaintenance() {
+        this.status = EquipmentStatus.AVAILABLE;
+    }
+
 
     public Long getId() {
         return id;
@@ -48,11 +76,19 @@ public class Equipment {
         this.type = type;
     }
 
-    public String getStatus() {
+    public EquipmentStatus getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(EquipmentStatus status) {
         this.status = status;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+
+    public Long getVersion() { 
+        return version; 
     }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/EquipmentStatus.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/EquipmentStatus.java
@@ -1,0 +1,7 @@
+package com.lablend.backend.entity;
+
+public enum EquipmentStatus {
+    AVAILABLE,
+    RESERVED,
+    UNDER_MAINTENANCE
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/EquipmentService.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/EquipmentService.java
@@ -10,4 +10,5 @@ public interface EquipmentService {
     List<Equipment> getAllEquipment();
     Equipment updateEquipment(Long id, Equipment equipment);
     void deleteEquipment(Long id);
+    Equipment reserveEquipment(Long id);
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/EquipmentServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/EquipmentServiceImpl.java
@@ -1,8 +1,12 @@
 package com.lablend.backend.service.impl;
 
 import com.lablend.backend.entity.Equipment;
+import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.service.EquipmentService;
+
+import jakarta.transaction.Transactional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,19 +39,51 @@ public class EquipmentServiceImpl implements EquipmentService {
     }
 
     @Override
+    @Transactional
     public Equipment updateEquipment(Long id, Equipment equipment) {
         return equipmentRepository.findById(id)
                 .map(existingEquipment -> {
                     existingEquipment.setName(equipment.getName());
                     existingEquipment.setType(equipment.getType());
-                    existingEquipment.setStatus(equipment.getStatus());
-                    return equipmentRepository.save(existingEquipment);
-                })
-                .orElse(null);
+
+                    if (!existingEquipment.getStatus().equals(equipment.getStatus())) {
+                    applyStateTransition(existingEquipment, equipment.getStatus());
+                }
+                
+                return equipmentRepository.save(existingEquipment);
+            })
+            .orElse(null);
     }
+
+
+    private void applyStateTransition(Equipment equipment, EquipmentStatus newStatus) {
+        switch (newStatus) {
+            case RESERVED -> equipment.reserve();
+            case UNDER_MAINTENANCE -> equipment.startMaintenance();
+            case AVAILABLE -> {
+                if (equipment.getStatus() == EquipmentStatus.UNDER_MAINTENANCE) {
+                equipment.finishMaintenance();
+                } 
+                else {
+                equipment.setStatus(EquipmentStatus.AVAILABLE);
+                }
+            }
+        }
+    }
+
 
     @Override
     public void deleteEquipment(Long id) {
         equipmentRepository.deleteById(id);
+    }
+
+    @Transactional
+    public Equipment reserveEquipment(Long id) {
+        Equipment equipment = equipmentRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Equipment not found"));
+    
+        equipment.reserve(); 
+    
+        return equipmentRepository.save(equipment);
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/controller/EquipmentControllerTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/controller/EquipmentControllerTest.java
@@ -2,6 +2,7 @@ package com.lablend.backend.controller;
 
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.service.EquipmentService;
+import com.lablend.backend.entity.EquipmentStatus; 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -17,6 +18,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -35,13 +37,36 @@ class EquipmentControllerTest {
         equipment.setId(1L);
         equipment.setName("Microscope");
         equipment.setType("Optical");
-        equipment.setStatus("AVAILABLE");
+        equipment.setStatus(EquipmentStatus.AVAILABLE);
 
         when(equipmentService.getAllEquipment()).thenReturn(List.of(equipment));
 
         mockMvc.perform(get("/api/equipment"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("Microscope"));
+                .andExpect(jsonPath("$[0].name").value("Microscope"))
+                .andExpect(jsonPath("$[0].status").value("AVAILABLE"));
+    }
+
+    @Test
+    void testReserveEquipmentSuccess() throws Exception {
+        Equipment reservedEquipment = new Equipment("Microscope", "Optical", EquipmentStatus.RESERVED);
+        reservedEquipment.setId(1L);
+
+        when(equipmentService.reserveEquipment(1L)).thenReturn(reservedEquipment);
+
+        mockMvc.perform(put("/api/equipment/1/reserve"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RESERVED"));
+    }
+
+    @Test
+    void testReserveEquipmentFail_IllegalState() throws Exception {
+        when(equipmentService.reserveEquipment(1L))
+                .thenThrow(new IllegalStateException("Solo se puede reservar equipo disponible."));
+
+        mockMvc.perform(put("/api/equipment/1/reserve"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Solo se puede reservar equipo disponible."));
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/entity/EquipmentTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/entity/EquipmentTest.java
@@ -2,6 +2,7 @@ package com.lablend.backend.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,7 @@ public class EquipmentTest {
         equipment.setId(1L);
         equipment.setName("Microscope");
         equipment.setType("Optical");
-        equipment.setStatus("Available");
+        equipment.setStatus(EquipmentStatus.AVAILABLE);
     }
 
     @Test
@@ -25,7 +26,37 @@ public class EquipmentTest {
         assertEquals(1L, equipment.getId());
         assertEquals("Microscope", equipment.getName());
         assertEquals("Optical", equipment.getType());
-        assertEquals("Available", equipment.getStatus());
+        assertEquals(EquipmentStatus.AVAILABLE, equipment.getStatus());
+    }
+
+    @Test
+    public void testReserveTransitionSuccess() {
+        equipment.reserve();
+        assertEquals(EquipmentStatus.RESERVED, equipment.getStatus());
+    }
+
+    @Test
+    public void testReserveTransitionFail() {
+        equipment.setStatus(EquipmentStatus.UNDER_MAINTENANCE);
+        
+        assertThrows(IllegalStateException.class, () -> {
+            equipment.reserve();
+        });
+    }
+
+    @Test
+    public void testMaintenanceTransitions() {
+        equipment.startMaintenance();
+        assertEquals(EquipmentStatus.UNDER_MAINTENANCE, equipment.getStatus());
+
+        equipment.finishMaintenance();
+        assertEquals(EquipmentStatus.AVAILABLE, equipment.getStatus());
+    }
+
+    @Test
+    public void testVersionFieldExists() {
+        equipment.setVersion(1L);
+        assertEquals(1L, equipment.getVersion());
     }
 
     @Test
@@ -36,7 +67,7 @@ public class EquipmentTest {
         equipment.setType("Mechanical");
         assertEquals("Mechanical", equipment.getType());
 
-        equipment.setStatus("Loaned");
-        assertEquals("Loaned", equipment.getStatus());
+        equipment.setStatus(EquipmentStatus.RESERVED); 
+        assertEquals(EquipmentStatus.RESERVED, equipment.getStatus());
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/repository/EquipmentRepositoryTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/repository/EquipmentRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.lablend.backend.repository;
 
 import com.lablend.backend.entity.Equipment;
+import com.lablend.backend.entity.EquipmentStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ public class EquipmentRepositoryTest {
         equipment = new Equipment();
         equipment.setName("Microscope");
         equipment.setType("Optical");
-        equipment.setStatus("Available");
+        equipment.setStatus(EquipmentStatus.AVAILABLE);
     }
 
     @Test
@@ -31,6 +32,8 @@ public class EquipmentRepositoryTest {
         Equipment savedEquipment = equipmentRepository.save(equipment);
         assertThat(savedEquipment).isNotNull();
         assertThat(savedEquipment.getId()).isGreaterThan(0);
+        assertThat(savedEquipment.getStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
+        assertThat(savedEquipment.getVersion()).isEqualTo(0L);
     }
 
     @Test
@@ -39,6 +42,7 @@ public class EquipmentRepositoryTest {
         Equipment foundEquipment = equipmentRepository.findById(savedEquipment.getId()).orElse(null);
         assertThat(foundEquipment).isNotNull();
         assertThat(foundEquipment.getName()).isEqualTo(equipment.getName());
+        assertThat(foundEquipment.getStatus()).isEqualTo(EquipmentStatus.AVAILABLE);
     }
 
     @Test
@@ -48,6 +52,20 @@ public class EquipmentRepositoryTest {
         Equipment updatedEquipment = equipmentRepository.save(savedEquipment);
         assertThat(updatedEquipment.getName()).isEqualTo("Updated Microscope");
     }
+
+    @Test
+    public void testUpdateEquipmentStatusWithPattern() {
+        Equipment savedEquipment = equipmentRepository.save(equipment);
+        equipmentRepository.flush(); // <--- IMPORTANTE: Fuerza el insert en la DB
+
+        savedEquipment.reserve(); 
+    
+        Equipment updatedEquipment = equipmentRepository.saveAndFlush(savedEquipment); // <--- Usa saveAndFlush
+    
+        assertThat(updatedEquipment.getStatus()).isEqualTo(EquipmentStatus.RESERVED);
+    
+        assertThat(updatedEquipment.getVersion()).isEqualTo(1L);
+    }   
 
     @Test
     public void testDeleteEquipment() {

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/EquipmentServiceTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/EquipmentServiceTest.java
@@ -1,6 +1,7 @@
 package com.lablend.backend.service;
 
 import com.lablend.backend.entity.Equipment;
+import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.service.impl.EquipmentServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,8 @@ public class EquipmentServiceTest {
         equipment.setId(1L);
         equipment.setName("Microscope");
         equipment.setType("Optical");
-        equipment.setStatus("Available");
+        equipment.setStatus(EquipmentStatus.AVAILABLE);
+        equipment.setVersion(0L);
     }
 
     @Test
@@ -53,6 +55,41 @@ public class EquipmentServiceTest {
         assertEquals(1, equipmentList.size());
         assertEquals("Microscope", equipmentList.get(0).getName());
         verify(equipmentRepository, times(1)).findAll();
+    }
+
+    @Test
+    public void testReserveEquipmentSuccess() {
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+        when(equipmentRepository.save(any(Equipment.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        Equipment result = equipmentService.reserveEquipment(1L);
+
+        assertNotNull(result);
+        assertEquals(EquipmentStatus.RESERVED, result.getStatus());
+        verify(equipmentRepository).save(any(Equipment.class));
+    }
+
+    @Test
+    public void testReserveEquipmentFail_AlreadyReserved() {
+        equipment.setStatus(EquipmentStatus.RESERVED);
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+
+        assertThrows(IllegalStateException.class, () -> {
+            equipmentService.reserveEquipment(1L);
+        });
+    }
+
+    @Test
+    public void testUpdateEquipmentWithStateTransition() {
+        Equipment updatedInfo = new Equipment("Microscope V2", "Optical", EquipmentStatus.RESERVED);
+        
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+        when(equipmentRepository.save(any(Equipment.class))).thenReturn(updatedInfo);
+
+        Equipment result = equipmentService.updateEquipment(1L, updatedInfo);
+
+        assertNotNull(result);
+        assertEquals(EquipmentStatus.RESERVED, result.getStatus());
     }
 
     @Test


### PR DESCRIPTION
This PR addresses issues #61 and #62 by implementing robust state management and concurrency control for the Equipment entity. 

Regarding the State Pattern (#62), I refactored the Equipment entity to manage its own internal transitions. The logic now ensures that an item can only be reserved if its current status is AVAILABLE. If a user attempts to reserve an item that is already RESERVED, the system throws an IllegalStateException. This is captured by the EquipmentController, which has been updated to return a 400 Bad Request response, providing clear feedback to the client.

For the Optimistic Locking (#61), I added a @Version field to the Equipment model. This allows Hibernate to automatically track changes and prevent "lost updates" if two users try to modify the same record at the same time. During testing, I verified that the version number correctly increments from 0 to 1 upon a successful reservation, ensuring that the database remains consistent under load.