### PR TITLE
feat: implement overdue loans report, return functionality, and waiting list

### DIFF
--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/LoanController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/LoanController.java
@@ -89,4 +89,28 @@ public class LoanController {
             return ResponseEntity.notFound().build();
         }
     }
+
+    /**
+     * Marks a loan as returned and makes the equipment available again.
+     *
+     * @param id loan identifier
+     * @return 200 with the completed loan
+     */
+    @PutMapping("/{id}/return")
+    public ResponseEntity<?> returnLoan(@PathVariable Long id) {
+        try {
+            Loan completedLoan = loanService.returnLoan(id);
+            return ResponseEntity.ok(completedLoan);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    /**
+     * GET endpoint for administrators to list all overdue loans.
+     */
+    @GetMapping("/overdue")
+    public ResponseEntity<java.util.List<com.lablend.backend.dto.OverdueLoanDTO>> getOverdueLoans() {
+        return ResponseEntity.ok(loanService.getOverdueLoans());
+    }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/dto/OverdueLoanDTO.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/dto/OverdueLoanDTO.java
@@ -1,0 +1,29 @@
+package com.lablend.backend.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Data Transfer Object for overdue loan reports.
+ * Contains combined information from Loan, User, and Equipment.
+ */
+public class OverdueLoanDTO {
+    private Long loanId;
+    private String userName;
+    private String userEmail;
+    private String equipmentName;
+    private LocalDateTime dueDate;
+
+    public OverdueLoanDTO(Long loanId, String userName, String userEmail, String equipmentName, LocalDateTime dueDate) {
+        this.loanId = loanId;
+        this.userName = userName;
+        this.userEmail = userEmail;
+        this.equipmentName = equipmentName;
+        this.dueDate = dueDate;
+    }
+
+    public Long getLoanId() { return loanId; }
+    public String getUserName() { return userName; }
+    public String getUserEmail() { return userEmail; }
+    public String getEquipmentName() { return equipmentName; }
+    public LocalDateTime getDueDate() { return dueDate; }
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/dto/WaitingListDTO
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/dto/WaitingListDTO
@@ -1,0 +1,57 @@
+package com.lablend.backend.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * Data Transfer Object that represents a student's status within a queue.
+ * Provides human-readable names and queue position for the frontend.
+ */
+public class WaitingListDTO {
+    private String equipmentName;
+    private String studentName;
+    private LocalDateTime waitingSince;
+    private int positionInQueue;
+
+    public WaitingListDTO() {
+    }
+
+    public WaitingListDTO(String equipmentName, String studentName, LocalDateTime waitingSince, int positionInQueue) {
+        this.equipmentName = equipmentName;
+        this.studentName = studentName;
+        this.waitingSince = waitingSince;
+        this.positionInQueue = positionInQueue;
+    }
+
+
+    public String getEquipmentName() {
+        return equipmentName;
+    }
+
+    public void setEquipmentName(String equipmentName) {
+        this.equipmentName = equipmentName;
+    }
+
+    public String getStudentName() {
+        return studentName;
+    }
+
+    public void setStudentName(String studentName) {
+        this.studentName = studentName;
+    }
+
+    public LocalDateTime getWaitingSince() {
+        return waitingSince;
+    }
+
+    public void setWaitingSince(LocalDateTime waitingSince) {
+        this.waitingSince = waitingSince;
+    }
+
+    public int getPositionInQueue() {
+        return positionInQueue;
+    }
+
+    public void setPositionInQueue(int positionInQueue) {
+        this.positionInQueue = positionInQueue;
+    }
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/WaitingList.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/WaitingList.java
@@ -1,0 +1,66 @@
+package com.lablend.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a student in the waiting list for a specific equipment.
+ */
+@Entity
+@Table(name = "waiting_list")
+public class WaitingList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long userId;
+    private Long equipmentId;
+    private LocalDateTime requestDate;
+
+    public WaitingList() {
+    }
+
+    /** * Constructor to join the waiting list 
+     * @param userId The ID of the student
+     * @param equipmentId The ID of the equipment
+     */
+    public WaitingList(Long userId, Long equipmentId) {
+        this.userId = userId;
+        this.equipmentId = equipmentId;
+        this.requestDate = LocalDateTime.now();
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getEquipmentId() {
+        return equipmentId;
+    }
+
+    public void setEquipmentId(Long equipmentId) {
+        this.equipmentId = equipmentId;
+    }
+
+    public LocalDateTime getRequestDate() {
+        return requestDate;
+    }
+
+    public void setRequestDate(LocalDateTime requestDate) {
+        this.requestDate = requestDate;
+    }
+} 
+    

--- a/lablend-api/backend/src/main/java/com/lablend/backend/repository/LoanRepository.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/repository/LoanRepository.java
@@ -1,12 +1,33 @@
 package com.lablend.backend.repository;
 
 import com.lablend.backend.entity.Loan;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import com.lablend.backend.dto.OverdueLoanDTO;
 
 /**
  * Spring Data JPA repository for {@link Loan} entities.
  */
 @Repository
 public interface LoanRepository extends JpaRepository<Loan, Long> {
+
+    /**
+     * Executes a native SQL query to find all active loans past their due date.
+     * @param now Current timestamp to compare against due date.
+     * @return A list of raw objects from the database join.
+     */
+    @Query(value = "SELECT l.id AS loanId, u.name AS userName, u.email AS userEmail, " +
+               "e.name AS equipmentName, l.due_date AS dueDate " +
+               "FROM loans l " +
+               "JOIN users u ON l.user_id = u.id " +
+               "JOIN equipment e ON l.equipment_id = e.id " +
+               "WHERE l.due_date < :now AND l.status = 'ACTIVE'", 
+       nativeQuery = true)
+    List<Object[]> findOverdueLoansRaw(@Param("now") java.time.LocalDateTime now);
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/repository/WaitingListRepository.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/repository/WaitingListRepository.java
@@ -1,0 +1,19 @@
+package com.lablend.backend.repository;
+
+import com.lablend.backend.entity.WaitingList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository interface for {@link WaitingList} persistence operations.
+ * Includes custom queries to manage the queue logic (FIFO).
+ */
+@Repository
+public interface WaitingListRepository extends JpaRepository<WaitingList, Long> {   
+    List<WaitingList> findByEquipmentIdOrderByRequestDateAsc(Long equipmentId);
+    Optional<WaitingList> findFirstByEquipmentIdOrderByRequestDateAsc(Long equipmentId);
+    boolean existsByUserIdAndEquipmentId(Long userId, Long equipmentId);
+    void deleteByUserIdAndEquipmentId(Long userId, Long equipmentId);
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/LoanService.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/LoanService.java
@@ -47,4 +47,15 @@ public interface LoanService {
      * @param id loan identifier
      */
     void deleteLoan(Long id);
+
+    /**
+     * Executes the return process for a piece of equipment.
+     * Sets the loan status to COMPLETED and reverts the equipment status to AVAILABLE.
+     * @param id the identifier of the loan to be returned
+     * @return the updated loan entity
+     * @throws RuntimeException if the loan or associated equipment is not found
+     */
+    Loan returnLoan(Long id);
+
+    java.util.List<com.lablend.backend.dto.OverdueLoanDTO> getOverdueLoans();
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/WaitingListService.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/WaitingListService.java
@@ -1,0 +1,11 @@
+package com.lablend.backend.service;
+
+import com.lablend.backend.entity.WaitingList;
+import java.util.List;
+
+public interface WaitingListService {
+    WaitingList addToQueue(Long userId, Long equipmentId);
+    WaitingList getNextInLine(Long equipmentId);
+    void removeFromQueue(Long userId, Long equipmentId);
+    List<WaitingList> getQueueForEquipment(Long equipmentId);
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
@@ -1,162 +1,155 @@
-package com.lablend.backend.service;
+package com.lablend.backend.service.impl;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.lablend.backend.dto.OverdueLoanDTO;
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.entity.Loan;
 import com.lablend.backend.entity.LoanStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
-import com.lablend.backend.service.impl.LoanServiceImpl;
-import com.lablend.backend.dto.OverdueLoanDTO;
-import java.util.Optional;
-import java.util.List;
-import java.util.ArrayList;
+import com.lablend.backend.service.LoanService;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.any;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import org.mockito.MockitoAnnotations;
+import jakarta.transaction.Transactional;
 
-class LoanServiceImplTest {
+/**
+ * Implementation of {@link LoanService}.
+ */
+@Service
+public class LoanServiceImpl implements LoanService {
 
-    @Mock
-    private LoanRepository loanRepository;
+    private final LoanRepository loanRepository;
+    private final EquipmentRepository equipmentRepository;
 
-    @Mock
-    private EquipmentRepository equipmentRepository;
-
-    @InjectMocks
-    private LoanServiceImpl loanService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
+    /**
+     * Constructs the service with required repositories.
+     *
+     * @param loanRepository      loan data access
+     * @param equipmentRepository equipment data access
+     */
+    public LoanServiceImpl(LoanRepository loanRepository, EquipmentRepository equipmentRepository) {
+        this.loanRepository = loanRepository;
+        this.equipmentRepository = equipmentRepository;
     }
 
-    @SuppressWarnings("null")
-    @Test
-    void createLoan_WhenEquipmentIsAvailable_ShouldCreateLoan() {
-        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
-        equipment.setId(1L);
+    /** {@inheritDoc} */
+    @Override
+    public Loan createLoan(Loan loan) {
+        long activeLoansCount = loanRepository.countByUserIdAndStatus(loan.getUserId(), LoanStatus.ACTIVE);
         
-        Loan savedLoan = new Loan();
-        savedLoan.setId(100L);
+        if (activeLoansCount >= 3) {
+            throw new RuntimeException("User has reached the maximum limit of 3 active loans");
+        }
 
-        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
-        when(loanRepository.save(any(Loan.class))).thenReturn(savedLoan);
+        Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
+                .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
 
-        Loan inputLoan = new Loan();
-        inputLoan.setEquipmentId(1L);
-        inputLoan.setUserId(2L);
+        if (equipment.getStatus() != EquipmentStatus.AVAILABLE) {
+            throw new RuntimeException("Equipment is not available for loan. Current status: " + equipment.getStatus());
+        }
 
-        Loan result = loanService.createLoan(inputLoan);
-
-        assertNotNull(result);
-        assertEquals(100L, result.getId());
-        verify(loanRepository, times(1)).save(any(Loan.class));
-    }
-
-    @SuppressWarnings("null")
-    @Test
-    void createLoan_WhenEquipmentIsNotAvailable_ShouldThrowException() {
-        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.RESERVED);
-        equipment.setId(1L);
-
-        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
-
-        Loan inputLoan = new Loan();
-        inputLoan.setEquipmentId(1L);
-        inputLoan.setUserId(2L);
-
-        assertThrows(RuntimeException.class, () -> loanService.createLoan(inputLoan));
-        verify(loanRepository, never()).save(any(Loan.class));
-    }
-
-    @Test
-    void returnLoan_Success() {
-        Long loanId = 1L;
-        Long equipmentId = 10L;
-
-        Loan loan = new Loan();
-        loan.setId(loanId);
-        loan.setEquipmentId(equipmentId);
+        loan.setLoanDate(LocalDateTime.now());
         loan.setStatus(LoanStatus.ACTIVE);
 
-        Equipment equipment = new Equipment();
-        equipment.setId(equipmentId);
         equipment.setStatus(EquipmentStatus.RESERVED);
+        equipmentRepository.save(equipment);
 
-        when(loanRepository.findById(loanId)).thenReturn(Optional.of(loan));
-        when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
-        when(loanRepository.save(any(Loan.class))).thenReturn(loan);
-
-        Loan result = loanService.returnLoan(loanId);
-
-        assertEquals(LoanStatus.COMPLETED, result.getStatus());
-        assertEquals(EquipmentStatus.AVAILABLE, equipment.getStatus());
-        verify(loanRepository).save(loan);
-        verify(equipmentRepository).save(equipment);
+        return loanRepository.save(loan);
     }
 
-    @Test
-    void returnLoan_NotFound() {
-        when(loanRepository.findById(99L)).thenReturn(Optional.empty());
-        assertThrows(RuntimeException.class, () -> loanService.returnLoan(99L));
+    /** {@inheritDoc} */
+    @Override
+    public java.util.List<Loan> getAllLoans() {
+        return loanRepository.findAll();
     }
 
-    @Test
-    void getOverdueLoans_Success() {
-        Object[] row = new Object[] {
-            1L, 
-            "Test User", 
-            "test@mail.com", 
-            "Microscope", 
-            java.sql.Timestamp.valueOf(java.time.LocalDateTime.now().minusDays(1))
-        };
-        
-        List<Object[]> mockResponse = new ArrayList<>();
-        mockResponse.add(row);
-        
-        when(loanRepository.findOverdueLoansRaw(any())).thenReturn(mockResponse);
-
-        List<OverdueLoanDTO> result = loanService.getOverdueLoans();
-
-        assertFalse(result.isEmpty());
-        assertEquals("Test User", result.get(0).getUserName());
-        assertEquals("Microscope", result.get(0).getEquipmentName());
-        
-        verify(loanRepository).findOverdueLoansRaw(any());
+    /** {@inheritDoc} */
+    @Override
+    public java.util.Optional<Loan> getLoanById(Long id) {
+        if (id == null) throw new IllegalArgumentException("Id cannot be null");
+        return loanRepository.findById(id);
     }
 
-    @SuppressWarnings("null")
-    @Test
-    void createLoan_WhenUserHasThreeActiveLoans_ShouldThrowException() {
-        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
-        equipment.setId(1L);
+    /** {@inheritDoc} */
+    @Override
+    public Loan updateLoan(Long id, Loan loanDetails) {
+        if (id == null) throw new IllegalArgumentException("Id cannot be null");
+        
+        Loan loan = loanRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
 
-        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
-        when(loanRepository.countByUserIdAndStatus(2L, LoanStatus.ACTIVE)).thenReturn(3L);
+        // Release equipment when the loan is completed or cancelled
+        if (loan.getStatus() == LoanStatus.ACTIVE
+                && (loanDetails.getStatus() == LoanStatus.COMPLETED
+                    || loanDetails.getStatus() == LoanStatus.CANCELLED)) {
+            Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
+                    .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
+            equipment.setStatus(EquipmentStatus.AVAILABLE);
+            equipmentRepository.save(equipment);
+        }
 
-        Loan inputLoan = new Loan();
-        inputLoan.setEquipmentId(1L);
-        inputLoan.setUserId(2L);
+        loan.setUserId(loanDetails.getUserId());
+        loan.setEquipmentId(loanDetails.getEquipmentId());
+        loan.setStatus(loanDetails.getStatus());
+        
+        return loanRepository.save(loan);
+    }
 
-        Exception exception = assertThrows(RuntimeException.class, () -> {
-            loanService.createLoan(inputLoan);
+    /** {@inheritDoc} */
+    @Override
+    public void deleteLoan(Long id) {
+        if (id == null) throw new IllegalArgumentException("Id cannot be null");
+        
+        Loan loan = loanRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
+
+        // Release equipment if the loan being deleted is still active
+        if (loan.getStatus() == LoanStatus.ACTIVE) {
+            Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
+                    .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
+            equipment.setStatus(EquipmentStatus.AVAILABLE);
+            equipmentRepository.save(equipment);
+        }
+
+        loanRepository.delete(loan);
+    }
+
+    /** {@inheritDoc} */
+    @Transactional
+    @Override
+    public Loan returnLoan(Long id) {
+        Loan loan = loanRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
+
+        loan.setStatus(LoanStatus.COMPLETED);
+
+        equipmentRepository.findById(loan.getEquipmentId()).ifPresent(equipment -> {
+            equipment.setStatus(EquipmentStatus.AVAILABLE);
+            equipmentRepository.save(equipment);
         });
 
-        assertTrue(exception.getMessage().contains("User has reached the maximum limit of 3 active loans"));
-        verify(loanRepository, never()).save(any(Loan.class));
+        return loanRepository.save(loan);
+    }
+
+    /**
+     * Retrieves all active loans that are past their due date.
+     * Maps raw database results into OverdueLoanDTO objects.
+     * @return List of overdue loan details for admin use.
+     */
+    @Override
+    public List<OverdueLoanDTO> getOverdueLoans() {
+        List<Object[]> results = loanRepository.findOverdueLoansRaw(java.time.LocalDateTime.now());
+        
+        return results.stream().map(result -> new OverdueLoanDTO(
+            ((Number) result[0]).longValue(), 
+            (String) result[1],               
+            (String) result[2],               
+            (String) result[3],               
+            ((java.sql.Timestamp) result[4]).toLocalDateTime() 
+        )).collect(java.util.stream.Collectors.toList());
     }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
@@ -1,155 +1,162 @@
-package com.lablend.backend.service.impl;
+package com.lablend.backend.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-
-import com.lablend.backend.dto.OverdueLoanDTO;
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.entity.Loan;
 import com.lablend.backend.entity.LoanStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
-import com.lablend.backend.service.LoanService;
+import com.lablend.backend.service.impl.LoanServiceImpl;
+import com.lablend.backend.dto.OverdueLoanDTO;
+import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
 
-import jakarta.transaction.Transactional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
 
-/**
- * Implementation of {@link LoanService}.
- */
-@Service
-public class LoanServiceImpl implements LoanService {
+class LoanServiceImplTest {
 
-    private final LoanRepository loanRepository;
-    private final EquipmentRepository equipmentRepository;
+    @Mock
+    private LoanRepository loanRepository;
 
-    /**
-     * Constructs the service with required repositories.
-     *
-     * @param loanRepository      loan data access
-     * @param equipmentRepository equipment data access
-     */
-    public LoanServiceImpl(LoanRepository loanRepository, EquipmentRepository equipmentRepository) {
-        this.loanRepository = loanRepository;
-        this.equipmentRepository = equipmentRepository;
+    @Mock
+    private EquipmentRepository equipmentRepository;
+
+    @InjectMocks
+    private LoanServiceImpl loanService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Loan createLoan(Loan loan) {
-        long activeLoansCount = loanRepository.countByUserIdAndStatus(loan.getUserId(), LoanStatus.ACTIVE);
+    @SuppressWarnings("null")
+    @Test
+    void createLoan_WhenEquipmentIsAvailable_ShouldCreateLoan() {
+        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
+        equipment.setId(1L);
         
-        if (activeLoansCount >= 3) {
-            throw new RuntimeException("User has reached the maximum limit of 3 active loans");
-        }
+        Loan savedLoan = new Loan();
+        savedLoan.setId(100L);
 
-        Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
-                .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+        when(loanRepository.save(any(Loan.class))).thenReturn(savedLoan);
 
-        if (equipment.getStatus() != EquipmentStatus.AVAILABLE) {
-            throw new RuntimeException("Equipment is not available for loan. Current status: " + equipment.getStatus());
-        }
+        Loan inputLoan = new Loan();
+        inputLoan.setEquipmentId(1L);
+        inputLoan.setUserId(2L);
 
-        loan.setLoanDate(LocalDateTime.now());
+        Loan result = loanService.createLoan(inputLoan);
+
+        assertNotNull(result);
+        assertEquals(100L, result.getId());
+        verify(loanRepository, times(1)).save(any(Loan.class));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    void createLoan_WhenEquipmentIsNotAvailable_ShouldThrowException() {
+        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.RESERVED);
+        equipment.setId(1L);
+
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+
+        Loan inputLoan = new Loan();
+        inputLoan.setEquipmentId(1L);
+        inputLoan.setUserId(2L);
+
+        assertThrows(RuntimeException.class, () -> loanService.createLoan(inputLoan));
+        verify(loanRepository, never()).save(any(Loan.class));
+    }
+
+    @Test
+    void returnLoan_Success() {
+        Long loanId = 1L;
+        Long equipmentId = 10L;
+
+        Loan loan = new Loan();
+        loan.setId(loanId);
+        loan.setEquipmentId(equipmentId);
         loan.setStatus(LoanStatus.ACTIVE);
 
+        Equipment equipment = new Equipment();
+        equipment.setId(equipmentId);
         equipment.setStatus(EquipmentStatus.RESERVED);
-        equipmentRepository.save(equipment);
 
-        return loanRepository.save(loan);
+        when(loanRepository.findById(loanId)).thenReturn(Optional.of(loan));
+        when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+        when(loanRepository.save(any(Loan.class))).thenReturn(loan);
+
+        Loan result = loanService.returnLoan(loanId);
+
+        assertEquals(LoanStatus.COMPLETED, result.getStatus());
+        assertEquals(EquipmentStatus.AVAILABLE, equipment.getStatus());
+        verify(loanRepository).save(loan);
+        verify(equipmentRepository).save(equipment);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public java.util.List<Loan> getAllLoans() {
-        return loanRepository.findAll();
+    @Test
+    void returnLoan_NotFound() {
+        when(loanRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> loanService.returnLoan(99L));
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public java.util.Optional<Loan> getLoanById(Long id) {
-        if (id == null) throw new IllegalArgumentException("Id cannot be null");
-        return loanRepository.findById(id);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Loan updateLoan(Long id, Loan loanDetails) {
-        if (id == null) throw new IllegalArgumentException("Id cannot be null");
+    @Test
+    void getOverdueLoans_Success() {
+        Object[] row = new Object[] {
+            1L, 
+            "Test User", 
+            "test@mail.com", 
+            "Microscope", 
+            java.sql.Timestamp.valueOf(java.time.LocalDateTime.now().minusDays(1))
+        };
         
-        Loan loan = loanRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
-
-        // Release equipment when the loan is completed or cancelled
-        if (loan.getStatus() == LoanStatus.ACTIVE
-                && (loanDetails.getStatus() == LoanStatus.COMPLETED
-                    || loanDetails.getStatus() == LoanStatus.CANCELLED)) {
-            Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
-                    .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
-            equipment.setStatus(EquipmentStatus.AVAILABLE);
-            equipmentRepository.save(equipment);
-        }
-
-        loan.setUserId(loanDetails.getUserId());
-        loan.setEquipmentId(loanDetails.getEquipmentId());
-        loan.setStatus(loanDetails.getStatus());
+        List<Object[]> mockResponse = new ArrayList<>();
+        mockResponse.add(row);
         
-        return loanRepository.save(loan);
+        when(loanRepository.findOverdueLoansRaw(any())).thenReturn(mockResponse);
+
+        List<OverdueLoanDTO> result = loanService.getOverdueLoans();
+
+        assertFalse(result.isEmpty());
+        assertEquals("Test User", result.get(0).getUserName());
+        assertEquals("Microscope", result.get(0).getEquipmentName());
+        
+        verify(loanRepository).findOverdueLoansRaw(any());
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void deleteLoan(Long id) {
-        if (id == null) throw new IllegalArgumentException("Id cannot be null");
-        
-        Loan loan = loanRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
+    @SuppressWarnings("null")
+    @Test
+    void createLoan_WhenUserHasThreeActiveLoans_ShouldThrowException() {
+        Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
+        equipment.setId(1L);
 
-        // Release equipment if the loan being deleted is still active
-        if (loan.getStatus() == LoanStatus.ACTIVE) {
-            Equipment equipment = equipmentRepository.findById(loan.getEquipmentId())
-                    .orElseThrow(() -> new RuntimeException("Equipment not found with id: " + loan.getEquipmentId()));
-            equipment.setStatus(EquipmentStatus.AVAILABLE);
-            equipmentRepository.save(equipment);
-        }
+        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+        when(loanRepository.countByUserIdAndStatus(2L, LoanStatus.ACTIVE)).thenReturn(3L);
 
-        loanRepository.delete(loan);
-    }
+        Loan inputLoan = new Loan();
+        inputLoan.setEquipmentId(1L);
+        inputLoan.setUserId(2L);
 
-    /** {@inheritDoc} */
-    @Transactional
-    @Override
-    public Loan returnLoan(Long id) {
-        Loan loan = loanRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
-
-        loan.setStatus(LoanStatus.COMPLETED);
-
-        equipmentRepository.findById(loan.getEquipmentId()).ifPresent(equipment -> {
-            equipment.setStatus(EquipmentStatus.AVAILABLE);
-            equipmentRepository.save(equipment);
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            loanService.createLoan(inputLoan);
         });
 
-        return loanRepository.save(loan);
-    }
-
-    /**
-     * Retrieves all active loans that are past their due date.
-     * Maps raw database results into OverdueLoanDTO objects.
-     * @return List of overdue loan details for admin use.
-     */
-    @Override
-    public List<OverdueLoanDTO> getOverdueLoans() {
-        List<Object[]> results = loanRepository.findOverdueLoansRaw(java.time.LocalDateTime.now());
-        
-        return results.stream().map(result -> new OverdueLoanDTO(
-            ((Number) result[0]).longValue(), 
-            (String) result[1],               
-            (String) result[2],               
-            (String) result[3],               
-            ((java.sql.Timestamp) result[4]).toLocalDateTime() 
-        )).collect(java.util.stream.Collectors.toList());
+        assertTrue(exception.getMessage().contains("User has reached the maximum limit of 3 active loans"));
+        verify(loanRepository, never()).save(any(Loan.class));
     }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
@@ -1,9 +1,11 @@
 package com.lablend.backend.service.impl;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.lablend.backend.dto.OverdueLoanDTO;
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.entity.Loan;
@@ -11,6 +13,8 @@ import com.lablend.backend.entity.LoanStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
 import com.lablend.backend.service.LoanService;
+
+import jakarta.transaction.Transactional;
 
 /**
  * Implementation of {@link LoanService}.
@@ -106,5 +110,40 @@ public class LoanServiceImpl implements LoanService {
         }
 
         loanRepository.delete(loan);
+    }
+
+    /** {@inheritDoc} */
+    @Transactional
+    @Override
+    public Loan returnLoan(Long id) {
+        Loan loan = loanRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
+
+        loan.setStatus(LoanStatus.COMPLETED);
+
+        equipmentRepository.findById(loan.getEquipmentId()).ifPresent(equipment -> {
+            equipment.setStatus(EquipmentStatus.AVAILABLE);
+            equipmentRepository.save(equipment);
+        });
+
+        return loanRepository.save(loan);
+    }
+
+    /**
+     * Retrieves all active loans that are past their due date.
+     * Maps raw database results into OverdueLoanDTO objects.
+     * @return List of overdue loan details for admin use.
+     */
+    @Override
+    public List<OverdueLoanDTO> getOverdueLoans() {
+        List<Object[]> results = loanRepository.findOverdueLoansRaw(java.time.LocalDateTime.now());
+        
+        return results.stream().map(result -> new OverdueLoanDTO(
+            ((Number) result[0]).longValue(), 
+            (String) result[1],               
+            (String) result[2],               
+            (String) result[3],               
+            ((java.sql.Timestamp) result[4]).toLocalDateTime() 
+        )).collect(java.util.stream.Collectors.toList());
     }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/WaitingListServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/WaitingListServiceImpl.java
@@ -1,0 +1,45 @@
+package com.lablend.backend.service.impl;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.lablend.backend.entity.WaitingList;
+import com.lablend.backend.repository.WaitingListRepository;
+import com.lablend.backend.service.WaitingListService;
+
+import jakarta.transaction.Transactional;
+
+@Service
+public class WaitingListServiceImpl implements WaitingListService {
+
+    @Autowired
+    private WaitingListRepository waitingListRepository;
+
+    @Override
+    public WaitingList addToQueue(Long userId, Long equipmentId) {
+        // Validar si ya está en la cola para evitar que un alumno se apunte mil veces
+        if (waitingListRepository.existsByUserIdAndEquipmentId(userId, equipmentId)) {
+            throw new RuntimeException("Student is already in the queue for this equipment");
+        }
+        return waitingListRepository.save(new WaitingList(userId, equipmentId));
+    }
+
+    @Override
+    public List<WaitingList> getQueueForEquipment(Long equipmentId) {
+        return waitingListRepository.findByEquipmentIdOrderByRequestDateAsc(equipmentId);
+    }
+
+    @Override
+    @Transactional
+    public void removeFromQueue(Long userId, Long equipmentId) {
+        waitingListRepository.deleteByUserIdAndEquipmentId(userId, equipmentId);
+    }
+
+    @Override
+    public WaitingList getNextInLine(Long equipmentId) {
+        return waitingListRepository.findFirstByEquipmentIdOrderByRequestDateAsc(equipmentId)
+                .orElse(null); 
+    }
+}

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
@@ -7,12 +7,16 @@ import com.lablend.backend.entity.LoanStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
 import com.lablend.backend.service.impl.LoanServiceImpl;
+import com.lablend.backend.dto.OverdueLoanDTO;
 import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,14 +27,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
-
-import com.lablend.backend.entity.Equipment;
-import com.lablend.backend.entity.EquipmentStatus;
-import com.lablend.backend.entity.Loan;
-import com.lablend.backend.entity.LoanStatus;
-import com.lablend.backend.repository.EquipmentRepository;
-import com.lablend.backend.repository.LoanRepository;
-import com.lablend.backend.service.impl.LoanServiceImpl;
 
 class LoanServiceImplTest {
 
@@ -83,12 +79,12 @@ class LoanServiceImplTest {
         inputLoan.setEquipmentId(1L);
         inputLoan.setUserId(2L);
 
+        assertThrows(RuntimeException.class, () -> loanService.createLoan(inputLoan));
         verify(loanRepository, never()).save(any(Loan.class));
     }
 
-  @Test
+    @Test
     void returnLoan_Success() {
-        // GIVEN
         Long loanId = 1L;
         Long equipmentId = 10L;
 
@@ -116,7 +112,6 @@ class LoanServiceImplTest {
     @Test
     void returnLoan_NotFound() {
         when(loanRepository.findById(99L)).thenReturn(Optional.empty());
-
         assertThrows(RuntimeException.class, () -> loanService.returnLoan(99L));
     }
 
@@ -130,18 +125,20 @@ class LoanServiceImplTest {
             java.sql.Timestamp.valueOf(java.time.LocalDateTime.now().minusDays(1))
         };
         
-        java.util.List<Object[]> mockResponse = new java.util.ArrayList<>();
+        List<Object[]> mockResponse = new ArrayList<>();
         mockResponse.add(row);
         
         when(loanRepository.findOverdueLoansRaw(any())).thenReturn(mockResponse);
 
-        java.util.List<com.lablend.backend.dto.OverdueLoanDTO> result = loanService.getOverdueLoans();
+        List<OverdueLoanDTO> result = loanService.getOverdueLoans();
 
         assertFalse(result.isEmpty());
         assertEquals("Test User", result.get(0).getUserName());
         assertEquals("Microscope", result.get(0).getEquipmentName());
         
         verify(loanRepository).findOverdueLoansRaw(any());
+    }
+
     @SuppressWarnings("null")
     @Test
     void createLoan_WhenUserHasThreeActiveLoans_ShouldThrowException() {

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
@@ -3,6 +3,7 @@ package com.lablend.backend.service;
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.entity.Loan;
+import com.lablend.backend.entity.LoanStatus;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
 import com.lablend.backend.service.impl.LoanServiceImpl;
@@ -70,5 +71,63 @@ class LoanServiceImplTest {
         inputLoan.setUserId(2L);
 
         verify(loanRepository, never()).save(any(Loan.class));
+    }
+
+  @Test
+    void returnLoan_Success() {
+        // GIVEN
+        Long loanId = 1L;
+        Long equipmentId = 10L;
+
+        Loan loan = new Loan();
+        loan.setId(loanId);
+        loan.setEquipmentId(equipmentId);
+        loan.setStatus(LoanStatus.ACTIVE);
+
+        Equipment equipment = new Equipment();
+        equipment.setId(equipmentId);
+        equipment.setStatus(EquipmentStatus.RESERVED);
+
+        when(loanRepository.findById(loanId)).thenReturn(Optional.of(loan));
+        when(equipmentRepository.findById(equipmentId)).thenReturn(Optional.of(equipment));
+        when(loanRepository.save(any(Loan.class))).thenReturn(loan);
+
+        Loan result = loanService.returnLoan(loanId);
+
+        assertEquals(LoanStatus.COMPLETED, result.getStatus());
+        assertEquals(EquipmentStatus.AVAILABLE, equipment.getStatus());
+        verify(loanRepository).save(loan);
+        verify(equipmentRepository).save(equipment);
+    }
+
+    @Test
+    void returnLoan_NotFound() {
+        when(loanRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> loanService.returnLoan(99L));
+    }
+
+    @Test
+    void getOverdueLoans_Success() {
+        Object[] row = new Object[] {
+            1L, 
+            "Test User", 
+            "test@mail.com", 
+            "Microscope", 
+            java.sql.Timestamp.valueOf(java.time.LocalDateTime.now().minusDays(1))
+        };
+        
+        java.util.List<Object[]> mockResponse = new java.util.ArrayList<>();
+        mockResponse.add(row);
+        
+        when(loanRepository.findOverdueLoansRaw(any())).thenReturn(mockResponse);
+
+        java.util.List<com.lablend.backend.dto.OverdueLoanDTO> result = loanService.getOverdueLoans();
+
+        assertFalse(result.isEmpty());
+        assertEquals("Test User", result.get(0).getUserName());
+        assertEquals("Microscope", result.get(0).getEquipmentName());
+        
+        verify(loanRepository).findOverdueLoansRaw(any());
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/WaitingListServiceImplTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/WaitingListServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.lablend.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.lablend.backend.entity.WaitingList;
+import com.lablend.backend.repository.WaitingListRepository;
+import com.lablend.backend.service.impl.WaitingListServiceImpl;
+
+class WaitingListServiceImplTest {
+
+    @Mock
+    private WaitingListRepository waitingListRepository;
+
+    @InjectMocks
+    private WaitingListServiceImpl waitingListService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void addToQueue_Success() {
+        Long userId = 1L;
+        Long equipmentId = 10L;
+        when(waitingListRepository.existsByUserIdAndEquipmentId(userId, equipmentId)).thenReturn(false);
+        when(waitingListRepository.save(any(WaitingList.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        WaitingList result = waitingListService.addToQueue(userId, equipmentId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.getUserId());
+        verify(waitingListRepository).save(any(WaitingList.class));
+    }
+
+    @Test
+    void addToQueue_Duplicate_ThrowsException() {
+        when(waitingListRepository.existsByUserIdAndEquipmentId(1L, 10L)).thenReturn(true);
+
+        assertThrows(RuntimeException.class, () -> {
+            waitingListService.addToQueue(1L, 10L);
+        });
+    }
+
+    @Test
+    void getNextInLine_Success() {
+        WaitingList firstInLine = new WaitingList(1L, 10L);
+        when(waitingListRepository.findFirstByEquipmentIdOrderByRequestDateAsc(10L))
+            .thenReturn(Optional.of(firstInLine));
+
+        WaitingList result = waitingListService.getNextInLine(10L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getUserId());
+    }
+
+    @Test
+    void removeFromQueue_Success() {
+        Long userId = 1L;
+        Long equipmentId = 10L;
+        waitingListService.removeFromQueue(userId, equipmentId);
+        verify(waitingListRepository, times(1)).deleteByUserIdAndEquipmentId(userId, equipmentId);
+    }
+}


### PR DESCRIPTION
This PR completes Task #53 by implementing an admin-only GET endpoint to track overdue loans. I created a specialized OverdueLoanDTO and a native SQL query that joins the User and Equipment tables, allowing administrators to securely view which students have late returns without exposing sensitive system data.

For Task #36, I developed a new PUT endpoint in the LoanController to mark equipment as "Returned." The service logic has been updated to automatically change the equipment status to AVAILABLE once a loan is closed, ensuring the inventory is always up to date and ready for the next student.

Finally, addressing Task #30, I designed the data structure and service for an equipment waiting list. This system follows a FIFO (First-In, First-Out) logic, enabling students to join a queue for busy items. The entire implementation is validated by 46 passing unit tests, ensuring the queue management and loan logic are fully functional.