### PR TITLE
feat: add BLOCKED status to users and validate before loan creation

### DIFF
--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/UserController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/UserController.java
@@ -64,6 +64,16 @@ public class UserController {
         }
     }
     /**
+     * Retrieves all blocked users.
+     * Requires ADMIN role.
+     *
+     * @return List of blocked users with HTTP 200.
+     */
+    @GetMapping("/blocked")
+    public ResponseEntity<List<User>> getBlockedUsers() {
+        return ResponseEntity.ok(userService.getBlockedUsers());
+    }
+    /**
      * Retrieves a user by ID.
      * @param id The ID of the user to retrieve.
      * @return The user with HTTP 200, or HTTP 404 if not found.
@@ -82,6 +92,46 @@ public class UserController {
     public ResponseEntity<List<User>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
     }
+
+
+    /**
+     * Blocks a user by ID. Only USER-role accounts can be blocked.
+     * Requires ADMIN role.
+     *
+     * @param id The ID of the user to block.
+     * @return HTTP 200 on success, 404 if not found, 409 if target is an admin.
+     */
+    @PutMapping("/{id}/block")
+    public ResponseEntity<?> blockUser(@PathVariable Long id) {
+        try {
+            userService.blockUser(id);
+            return ResponseEntity.ok().build();
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+
+    /**
+     * Unblocks a previously blocked user.
+     * Requires ADMIN role.
+     *
+     * @param id The ID of the user to unblock.
+     * @return HTTP 200 on success, 404 if not found.
+     */
+    @PutMapping("/{id}/unblock")
+    public ResponseEntity<?> unblockUser(@PathVariable Long id) {
+        try {
+            userService.unblockUser(id);
+            return ResponseEntity.ok().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    
 
     
 

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/User.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/User.java
@@ -7,7 +7,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
+import jakarta.persistence.Column;
+import com.lablend.backend.entity.UserStatus;
+import com.lablend.backend.entity.UserRole;
 /**
  * Entity representing a user in the system.
  * @version 1.0
@@ -35,6 +37,11 @@ public class User {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    /**Status of user */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
     /** Default constructor */
     public User() {
     }
@@ -50,6 +57,21 @@ public class User {
         this.email = email;
         this.password = password;
         this.role = role;
+        this.status = UserStatus.ACTIVE;
+    }
+    /** Constructor for creating a user with specified attributes 
+     * @param name  the name of the user
+     * @param email the email of the user
+     * @param password the password of the user
+     * @param role  the role of the user (e.g., ADMIN, USER)
+     * @param status the status of te user 
+    */
+    public User(String name, String email, String password, UserRole role, UserStatus status) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.status = status;
     }
 
     /** @return unique ID of a user */
@@ -100,5 +122,16 @@ public class User {
     /** Setter for the role of a user */
     public void setRole(UserRole role) {
         this.role = role;
+    }
+
+
+    /**Get the status of a user */
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    /** Setter for the status of a user */
+    public void setStatus(UserStatus status) {
+        this.status = status;
     }
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/UserStatus.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/UserStatus.java
@@ -1,0 +1,12 @@
+package com.lablend.backend.entity;
+
+/**
+ * Possible statuses a {@link User} can have.
+ * @version 1.0
+ */
+public enum UserStatus {
+    /** Active user, can perform actions */
+    ACTIVE,
+    /** Blocked user, cannot borrow equipment */
+    BLOCKED
+}

--- a/lablend-api/backend/src/main/java/com/lablend/backend/repository/UserRepository.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/repository/UserRepository.java
@@ -2,9 +2,10 @@ package com.lablend.backend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
+import java.util.List;
 import com.lablend.backend.entity.User;
 import java.util.Optional;
+import com.lablend.backend.entity.UserStatus;
 
 /**
  * Repository interface for managing {@link User} entities.
@@ -14,4 +15,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByName(String name);
+    List<User> findByStatus(UserStatus status);
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/UserService.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/UserService.java
@@ -14,4 +14,8 @@ public interface UserService {
     void deleteUser(Long id);
     Optional<User> getUserById(Long id);
     List<User> getAllUsers();
+    void blockUser(Long id);
+    void unblockUser(Long id);
+    List<User> getBlockedUsers();
+    boolean isUserBlocked(Long id);
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
-
+import com.lablend.backend.repository.UserRepository;
 import com.lablend.backend.dto.OverdueLoanDTO;
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
@@ -24,6 +24,7 @@ public class LoanServiceImpl implements LoanService {
 
     private final LoanRepository loanRepository;
     private final EquipmentRepository equipmentRepository;
+    private final UserRepository userRepository;
 
     /**
      * Constructs the service with required repositories.
@@ -31,14 +32,21 @@ public class LoanServiceImpl implements LoanService {
      * @param loanRepository      loan data access
      * @param equipmentRepository equipment data access
      */
-    public LoanServiceImpl(LoanRepository loanRepository, EquipmentRepository equipmentRepository) {
+    public LoanServiceImpl(LoanRepository loanRepository, EquipmentRepository equipmentRepository, UserRepository userRepository) {
         this.loanRepository = loanRepository;
         this.equipmentRepository = equipmentRepository;
+        this.userRepository = userRepository;
     }
 
     /** {@inheritDoc} */
     @Override
     public Loan createLoan(Loan loan) {
+        com.lablend.backend.entity.User user = userRepository.findById(loan.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + loan.getUserId()));
+        if (user.getStatus() == com.lablend.backend.entity.UserStatus.BLOCKED) {
+            throw new IllegalStateException("User is blocked and cannot borrow equipment");
+        }
+
         long activeLoansCount = loanRepository.countByUserIdAndStatus(loan.getUserId(), LoanStatus.ACTIVE);
         
         if (activeLoansCount >= 3) {

--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/UserServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/UserServiceImpl.java
@@ -6,6 +6,9 @@ import com.lablend.backend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import com.lablend.backend.entity.UserRole;
+import com.lablend.backend.entity.UserStatus;
+
 
 import java.util.List;
 import java.util.Optional;
@@ -104,6 +107,63 @@ public class UserServiceImpl implements UserService {
     @Override
     public List<User> getAllUsers() {
         return userRepository.findAll();
+    }
+
+
+    /**
+     * Blocks a user by setting their status to BLOCKED.
+     *
+     * <p>Administrators cannot be blocked.</p>
+     *
+     * @param id the ID of the user to block
+     * @throws RuntimeException if no user exists with the given ID
+     * @throws IllegalStateException if the user is an administrator
+     */
+    @Override
+    public void blockUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + id));
+        if (user.getRole() == UserRole.ADMIN) {
+            throw new IllegalStateException("Administrators cannot be blocked");
+        }
+        user.setStatus(UserStatus.BLOCKED);
+        userRepository.save(user);
+    }
+
+    /**
+     * Unblocks a user by setting their status to ACTIVE.
+     *
+     * @param id the ID of the user to unblock
+     * @throws RuntimeException if no user exists with the given ID
+     */
+    @Override
+    public void unblockUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + id));
+        user.setStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+    }
+    /**
+     * Retrieves all users whose status is BLOCKED.
+     *
+     * @return a list of blocked users
+     */
+    @Override
+    public List<User> getBlockedUsers() {
+        return userRepository.findByStatus(UserStatus.BLOCKED);
+    }
+    /**
+     * Checks whether a user is currently blocked.
+     *
+     * @param id the ID of the user to check
+     * @return true if the user is blocked, false otherwise
+     * @throws RuntimeException if no user exists with the given ID
+     */
+    @Override
+    public boolean isUserBlocked(Long id) {
+        return userRepository.findById(id)
+                .map(u -> u.getStatus() == UserStatus.BLOCKED)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + id));
     }
 
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/acceptance/LoanAcceptanceTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/acceptance/LoanAcceptanceTest.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import com.lablend.backend.entity.UserStatus;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -78,5 +80,37 @@ public class LoanAcceptanceTest {
         assertEquals(EquipmentStatus.RESERVED, updatedEq.getStatus());
 
         logger.info("Test de Aceptacion superado: El ciclo completo de prestamo funciono como se esperaba.");
+    }
+
+    /**Blocked user test */
+    @Test
+    public void blockedUserCannotBorrowEquipment() {
+        logger.info("Iniciando Test de Aceptacion: Usuario bloqueado no puede solicitar prestamo");
+
+        User blocked = new User();
+        blocked.setName("blocked_student");
+        blocked.setEmail("blocked@deusto.es");
+        blocked.setPassword("12345");
+        blocked.setRole(UserRole.USER);
+        blocked.setStatus(UserStatus.BLOCKED);
+        blocked = userRepository.save(blocked);
+
+        Equipment eq = new Equipment("Microscopio", "Optica", EquipmentStatus.AVAILABLE);
+        eq = equipmentRepository.save(eq);
+
+        final Long userId = blocked.getId();
+        final Long equipmentId = eq.getId();
+
+        Loan loan = new Loan();
+        loan.setUserId(userId);
+        loan.setEquipmentId(equipmentId);
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> loanService.createLoan(loan)
+        );
+        assertEquals("User is blocked and cannot borrow equipment", ex.getMessage());
+
+        logger.info("Test de Aceptacion superado: Usuario bloqueado fue rechazado correctamente.");
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/controller/LoanControllerTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/controller/LoanControllerTest.java
@@ -217,4 +217,16 @@ class LoanControllerTest {
                 .andExpect(jsonPath("$[0].userName").value("Test User"))
                 .andExpect(jsonPath("$[0].equipmentName").value("Microscope"));
     }
+
+    @Test
+    void createLoan_BlockedUser_ShouldReturn409() throws Exception {
+        when(loanService.createLoan(any(Loan.class)))
+                .thenThrow(new IllegalStateException("User is blocked and cannot borrow equipment"));
+
+        mockMvc.perform(post("/api/loans")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(testLoan)))
+                .andExpect(status().isConflict())
+                .andExpect(content().string("User is blocked and cannot borrow equipment"));
+    }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/controller/UserControllerTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/controller/UserControllerTest.java
@@ -11,6 +11,10 @@ import com.lablend.backend.auth.filter.JwtAuthenticationFilter;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.lablend.backend.entity.UserStatus;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -150,5 +154,68 @@ class UserControllerTest {
     void testDeleteUser() throws Exception {
         mockMvc.perform(delete("/api/users/1"))
                 .andExpect(status().isNoContent());
+    }
+
+
+    /**Blocked status tests */
+    @Test
+    void testBlockUser_Success() throws Exception {
+        doNothing().when(userService).blockUser(1L);
+
+        mockMvc.perform(put("/api/users/1/block"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testBlockUser_AdminConflict() throws Exception {
+        doThrow(new IllegalStateException("Administrators cannot be blocked"))
+                .when(userService).blockUser(1L);
+
+        mockMvc.perform(put("/api/users/1/block"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string("Administrators cannot be blocked"));
+    }
+
+    @Test
+    void testBlockUser_NotFound() throws Exception {
+        doThrow(new RuntimeException("User not found"))
+                .when(userService).blockUser(99L);
+
+        mockMvc.perform(put("/api/users/99/block"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testUnblockUser_Success() throws Exception {
+        doNothing().when(userService).unblockUser(1L);
+
+        mockMvc.perform(put("/api/users/1/unblock"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testUnblockUser_NotFound() throws Exception {
+        doThrow(new RuntimeException("User not found"))
+                .when(userService).unblockUser(99L);
+
+        mockMvc.perform(put("/api/users/99/unblock"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testGetBlockedUsers() throws Exception {
+        User blocked = new User();
+        blocked.setId(2L);
+        blocked.setName("Blocked User");
+        blocked.setEmail("blocked@uni.com");
+        blocked.setRole(UserRole.USER);
+        blocked.setStatus(UserStatus.BLOCKED);
+
+        when(userService.getBlockedUsers()).thenReturn(List.of(blocked));
+
+        mockMvc.perform(get("/api/users/blocked"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Blocked User"))
+                .andExpect(jsonPath("$[0].status").value("BLOCKED"));
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/repository/UserRepositoryTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/repository/UserRepositoryTest.java
@@ -1,11 +1,14 @@
 package com.lablend.backend.repository;
 
+import java.util.List;
 import com.lablend.backend.entity.User;
+import com.lablend.backend.entity.UserStatus;
 import com.lablend.backend.entity.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,5 +68,24 @@ public class UserRepositoryTest {
         userRepository.delete(savedUser);
         User deletedUser = userRepository.findById(savedUser.getId()).orElse(null);
         assertThat(deletedUser).isNull();
+    }
+
+    @Test
+    public void testFindByStatus_ActiveUsers() {
+        userRepository.save(user); 
+
+        List<User> activeUsers = userRepository.findByStatus(UserStatus.ACTIVE);
+        assertThat(activeUsers).isNotEmpty();
+        assertThat(activeUsers).allMatch(u -> u.getStatus() == UserStatus.ACTIVE);
+    }
+
+    @Test
+    public void testFindByStatus_BlockedUsers() {
+        user.setStatus(UserStatus.BLOCKED);
+        userRepository.save(user);
+
+        List<User> blockedUsers = userRepository.findByStatus(UserStatus.BLOCKED);
+        assertThat(blockedUsers).hasSize(1);
+        assertThat(blockedUsers.get(0).getName()).isEqualTo("Jorge");
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanPerformanceTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanPerformanceTest.java
@@ -69,6 +69,8 @@ public class LoanPerformanceTest {
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(equipmentRepository.findById(2L)).thenReturn(Optional.of(equipment));
             when(loanRepository.save(any(Loan.class))).thenReturn(loan);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(loanRepository.countByUserIdAndStatus(1L, LoanStatus.ACTIVE)).thenReturn(0L);
         }
 
         Loan created = loanService.createLoan(loan);

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
@@ -4,8 +4,12 @@ import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.entity.EquipmentStatus;
 import com.lablend.backend.entity.Loan;
 import com.lablend.backend.entity.LoanStatus;
+import com.lablend.backend.entity.User;
+import com.lablend.backend.entity.UserStatus;
+import com.lablend.backend.entity.UserRole;
 import com.lablend.backend.repository.EquipmentRepository;
 import com.lablend.backend.repository.LoanRepository;
+import com.lablend.backend.repository.UserRepository;
 import com.lablend.backend.service.impl.LoanServiceImpl;
 import com.lablend.backend.dto.OverdueLoanDTO;
 import java.util.Optional;
@@ -36,8 +40,13 @@ class LoanServiceImplTest {
     @Mock
     private EquipmentRepository equipmentRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
+
     @InjectMocks
     private LoanServiceImpl loanService;
+
 
     @BeforeEach
     void setUp() {
@@ -47,12 +56,18 @@ class LoanServiceImplTest {
     @SuppressWarnings("null")
     @Test
     void createLoan_WhenEquipmentIsAvailable_ShouldCreateLoan() {
+        User user = new User();
+        user.setId(2L);
+        user.setStatus(UserStatus.ACTIVE);
+
         Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
         equipment.setId(1L);
-        
+
         Loan savedLoan = new Loan();
         savedLoan.setId(100L);
 
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(loanRepository.countByUserIdAndStatus(2L, LoanStatus.ACTIVE)).thenReturn(0L);
         when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
         when(loanRepository.save(any(Loan.class))).thenReturn(savedLoan);
 
@@ -70,9 +85,15 @@ class LoanServiceImplTest {
     @SuppressWarnings("null")
     @Test
     void createLoan_WhenEquipmentIsNotAvailable_ShouldThrowException() {
+        User user = new User();
+        user.setId(2L);
+        user.setStatus(UserStatus.ACTIVE);
+
         Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.RESERVED);
         equipment.setId(1L);
 
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+        when(loanRepository.countByUserIdAndStatus(2L, LoanStatus.ACTIVE)).thenReturn(0L);
         when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
 
         Loan inputLoan = new Loan();
@@ -142,10 +163,14 @@ class LoanServiceImplTest {
     @SuppressWarnings("null")
     @Test
     void createLoan_WhenUserHasThreeActiveLoans_ShouldThrowException() {
+        User user = new User();
+        user.setId(2L);
+        user.setStatus(UserStatus.ACTIVE);
+
         Equipment equipment = new Equipment("Microscope", "Lab", EquipmentStatus.AVAILABLE);
         equipment.setId(1L);
 
-        when(equipmentRepository.findById(1L)).thenReturn(Optional.of(equipment));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
         when(loanRepository.countByUserIdAndStatus(2L, LoanStatus.ACTIVE)).thenReturn(3L);
 
         Loan inputLoan = new Loan();
@@ -317,5 +342,26 @@ class LoanServiceImplTest {
         });
 
         assertTrue(exception.getMessage().contains("Loan not found with id: 1"));
+    }
+
+    @Test
+    void createLoan_WhenUserIsBlocked_ShouldThrowException() {
+        User user = new User();
+        user.setId(2L);
+        user.setStatus(UserStatus.BLOCKED);
+
+        when(userRepository.findById(2L)).thenReturn(Optional.of(user));
+
+        Loan inputLoan = new Loan();
+        inputLoan.setEquipmentId(1L);
+        inputLoan.setUserId(2L);
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            loanService.createLoan(inputLoan);
+        });
+
+        assertTrue(exception.getMessage().contains("User is blocked and cannot borrow equipment"));
+        verify(loanRepository, never()).save(any(Loan.class));
+        verify(equipmentRepository, never()).findById(any());
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/UserServiceTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import com.lablend.backend.entity.UserStatus;
 
 import java.util.Arrays;
 import java.util.List;
@@ -104,5 +105,57 @@ public class UserServiceTest {
         assertThrows(RuntimeException.class, () -> {
             userService.deleteUser(99L);
         });
+    }
+
+    @Test
+    public void testBlockUser_Success() {
+        user.setRole(UserRole.USER);
+        user.setStatus(UserStatus.ACTIVE);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        userService.blockUser(1L);
+
+        assertEquals(UserStatus.BLOCKED, user.getStatus());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    public void testBlockUser_AdminShouldThrow() {
+        user.setRole(UserRole.ADMIN);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalStateException.class, () -> userService.blockUser(1L));
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    public void testBlockUser_NotFound() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(RuntimeException.class, () -> userService.blockUser(99L));
+    }
+
+    @Test
+    public void testUnblockUser_Success() {
+        user.setStatus(UserStatus.BLOCKED);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        userService.unblockUser(1L);
+
+        assertEquals(UserStatus.ACTIVE, user.getStatus());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    public void testGetBlockedUsers() {
+        user.setStatus(UserStatus.BLOCKED);
+        when(userRepository.findByStatus(UserStatus.BLOCKED)).thenReturn(List.of(user));
+
+        List<User> blocked = userService.getBlockedUsers();
+
+        assertEquals(1, blocked.size());
+        assertEquals(UserStatus.BLOCKED, blocked.get(0).getStatus());
+        verify(userRepository).findByStatus(UserStatus.BLOCKED);
     }
 }


### PR DESCRIPTION
- Add UserStatus enum (ACTIVE, BLOCKED)
- Add status field to User entity with default ACTIVE
- Add findByStatus query method to UserRepository
- Add blockUser, unblockUser, getBlockedUsers to UserService
- Validate blocked status in LoanServiceImpl before creating loan
- Add block/unblock/blocked endpoints to UserController (admin only)
- Restrict admin endpoints in SecurityConfig
- Update all affected tests

Closes #94
Closes #95.