### PR TITLE
feat/docs: implement manual review logic, admin dashboard, and swagger

### DIFF
--- a/lablend-api/backend/src/main/java/com/lablend/backend/auth/controller/AuthController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/auth/controller/AuthController.java
@@ -5,6 +5,12 @@ import com.lablend.backend.auth.dto.LoginResponse;
 import com.lablend.backend.auth.service.JwtService;
 import com.lablend.backend.entity.User;
 import com.lablend.backend.repository.UserRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,6 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "Authentication", description = "Endpoints for user authentication, token generation, and session management.")
+
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
@@ -38,6 +46,16 @@ public class AuthController {
     }
 
     @PostMapping("/login")
+    @Operation(
+        summary = "Authenticate user and generate JWT token", 
+        description = "Validates the user credentials (username/email and password). If valid, generates a secure JSON Web Token (JWT) containing the user's role and database ID for session authorization."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Successfully authenticated. Returns a valid JWT bearer token."),
+        @ApiResponse(responseCode = "400", description = "Bad Request: Username/principal or password payload is missing or blank."),
+        @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid credentials or authenticated user account not found.")
+    })
+
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         if (request.principal() == null || request.principal().isBlank() || request.password() == null) {
             return ResponseEntity.badRequest().build();

--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/EquipmentController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/EquipmentController.java
@@ -2,6 +2,12 @@ package com.lablend.backend.controller;
 
 import com.lablend.backend.entity.Equipment;
 import com.lablend.backend.service.EquipmentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,12 +24,11 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/equipment")
+@Tag(name = "Equipment Management", description = "Endpoints for managing laboratory equipment inventory, tracking availability states, and reservations.")
 public class EquipmentController {
 
     @Autowired
     private EquipmentService equipmentService;
-
-    
 
     /**
      * Retrieves one equipment record by identifier.
@@ -31,7 +36,13 @@ public class EquipmentController {
      * @param id equipment identifier
      * @return 200 with equipment when found, 404 otherwise
      */
+    
     @GetMapping("/{id}")
+    @Operation(summary = "Get equipment by ID", description = "Fetches the full details of a specific piece of laboratory equipment using its unique identifier.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Equipment successfully found and returned"),
+        @ApiResponse(responseCode = "404", description = "Equipment not found with the specified ID")
+    })
     public ResponseEntity<Equipment> getEquipmentById(@PathVariable Long id) {
         return equipmentService.getEquipmentById(id)
                 .map(ResponseEntity::ok)
@@ -46,6 +57,11 @@ public class EquipmentController {
      */
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Create a new equipment record", description = "Adds a brand new equipment item to the inventory system. Requires ADMIN role.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Equipment successfully registered into inventory"),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Access denied. Missing required ADMIN privileges.")
+    })
     public Equipment createEquipment(@RequestBody Equipment equipment) {
         return equipmentService.createEquipment(equipment);
     }
@@ -59,6 +75,12 @@ public class EquipmentController {
      */
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update an existing equipment item", description = "Modifies data sheets, naming, or attributes of an existing equipment record by ID. Requires ADMIN role.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Equipment successfully updated"),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Missing ADMIN role"),
+        @ApiResponse(responseCode = "404", description = "Equipment not found with the provided ID")
+    })
     public ResponseEntity<Equipment> updateEquipment(@PathVariable Long id, @RequestBody Equipment equipment) {
         Equipment updatedEquipment = equipmentService.updateEquipment(id, equipment);
         if (updatedEquipment != null) {
@@ -75,6 +97,12 @@ public class EquipmentController {
      */
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Delete an equipment item by ID", description = "Permanently drops an equipment record out of the inventory registry database. Requires ADMIN role.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "24", description = "Equipment successfully purged from database"),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Missing ADMIN privileges"),
+        @ApiResponse(responseCode = "404", description = "Equipment not found")
+    })
     public ResponseEntity<Void> deleteEquipment(@PathVariable Long id) {
         if (equipmentService.getEquipmentById(id).isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -92,6 +120,13 @@ public class EquipmentController {
      */
     @PutMapping("/{id}/reserve")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Reserve an equipment item", description = "Transitions an equipment piece state to reserved if currently available. Requires ADMIN role.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Equipment successfully locked into a reservation state"),
+        @ApiResponse(responseCode = "400", description = "Bad Request: Illegal state transition (e.g., equipment is broken or already loaned)"),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Missing ADMIN privileges"),
+        @ApiResponse(responseCode = "404", description = "Equipment not found")
+    })
     public ResponseEntity<?> reserveEquipment(@PathVariable Long id) {
         try {
             Equipment reserved = equipmentService.reserveEquipment(id);
@@ -113,6 +148,8 @@ public class EquipmentController {
      *         along with metadata such as total pages and total elements.
      */
     @GetMapping
+    @Operation(summary = "Get paginated list of equipment", description = "Fetches a slice of the equipment table. Supports zero-based offset page indexing and custom page sizing elements.")
+    @ApiResponse(responseCode = "200", description = "Successfully pulled paginated chunk of items from database context")
     public Page<Equipment> getAll(
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size

--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/LoanController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/LoanController.java
@@ -2,6 +2,12 @@ package com.lablend.backend.controller;
 
 import com.lablend.backend.entity.Loan;
 import com.lablend.backend.service.LoanService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/api/loans")
+@Tag(name = "Loan Management", description = "Endpoints for managing laboratory equipment loans, processing returns, managing extensions, and tracking overdue items.")
 public class LoanController {
 
     @Autowired
@@ -23,6 +30,8 @@ public class LoanController {
      * @return list of all loans
      */
     @GetMapping
+    @Operation(summary = "Get all loan records", description = "Retrieves a comprehensive history and active list of all laboratory equipment loans.")
+    @ApiResponse(responseCode = "200", description = "Successfully retrieved all loans list")
     public ResponseEntity<java.util.List<Loan>> getAllLoans() {
         return ResponseEntity.ok(loanService.getAllLoans());
     }
@@ -34,6 +43,11 @@ public class LoanController {
      * @return 200 with the loan when found, 404 otherwise
      */
     @GetMapping("/{id}")
+    @Operation(summary = "Get a loan by ID", description = "Fetches tracking data and timeline metrics of a specific loan entry via its database ID.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Loan details successfully retrieved"),
+        @ApiResponse(responseCode = "404", description = "Loan record not found with the specified ID")
+    })
     public ResponseEntity<Loan> getLoanById(@PathVariable Long id) {
         return loanService.getLoanById(id)
                 .map(ResponseEntity::ok)
@@ -48,6 +62,12 @@ public class LoanController {
      * @return 201 with the created loan, or 400 if the request is invalid
      */
     @PostMapping
+    @Operation(summary = "Create a new equipment loan", description = "Registers an equipment request allocation. The target equipment status must be free; transitions to RESERVED status immediately upon success.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Loan allocation entry successfully initialized"),
+        @ApiResponse(responseCode = "400", description = "Bad Request: Supplied request entity syntax missing critical references (userId/equipmentId)"),
+        @ApiResponse(responseCode = "409", description = "Conflict: Target equipment item is already reserved or active in another loan session")
+    })
     public ResponseEntity<?> createLoan(@RequestBody Loan loan) {
         try {
             Loan createdLoan = loanService.createLoan(loan);
@@ -67,6 +87,11 @@ public class LoanController {
      * @return 200 with the updated loan, 404 when not found
      */
     @PutMapping("/{id}")
+    @Operation(summary = "Update an existing loan tracking schema", description = "Overrides timestamps, system metadata or status data points on an existing active loan sheet.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Loan logs successfully patched"),
+        @ApiResponse(responseCode = "404", description = "Target loan document ID match not found")
+    })
     public ResponseEntity<Loan> updateLoan(@PathVariable Long id, @RequestBody Loan loan) {
         try {
             Loan updatedLoan = loanService.updateLoan(id, loan);
@@ -83,6 +108,11 @@ public class LoanController {
      * @return 204 when deleted, 404 when not found
      */
     @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a loan record", description = "Hard deletes a legacy or mistyped loan application index directly out of backend store.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "24", description = "Loan instance context discarded successfully"),
+        @ApiResponse(responseCode = "404", description = "No tracking context exists for target reference")
+    })
     public ResponseEntity<Void> deleteLoan(@PathVariable Long id) {
         try {
             loanService.deleteLoan(id);
@@ -99,6 +129,11 @@ public class LoanController {
      * @return 200 with the completed loan
      */
     @PutMapping("/{id}/return")
+    @Operation(summary = "Process equipment return", description = "Concludes an active loan lifecycle. Evaluates tracking deadlines, records resolution metrics, and switches equipment status back to AVAILABLE.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Equipment return acknowledged; lifecycle ended successfully"),
+        @ApiResponse(responseCode = "404", description = "Loan entity not matched")
+    })
     public ResponseEntity<?> returnLoan(@PathVariable Long id) {
         try {
             Loan completedLoan = loanService.returnLoan(id);
@@ -115,6 +150,12 @@ public class LoanController {
      * @return 200 with the extended loan, 409 if already extended or not active, 404 if not found
      */
     @PutMapping("/{id}/extend")
+    @Operation(summary = "Extend active loan duration timeline", description = "Grants extra runtime buffer margins over current deadlines. Business logic limitation: Every unique loan instance is eligible to call this feature exactly once.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Loan timeline extended successfully"),
+        @ApiResponse(responseCode = "409", description = "Conflict: Request rejected. Timeline has already consumed its single allocation expansion buffer or the current status is inactive"),
+        @ApiResponse(responseCode = "404", description = "Loan key references not matched")
+    })
     public ResponseEntity<?> extendLoan(@PathVariable Long id) {
         try {
             Loan extendedLoan = loanService.extendLoan(id);
@@ -130,6 +171,8 @@ public class LoanController {
      * GET endpoint for administrators to list all overdue loans.
      */
     @GetMapping("/overdue")
+    @Operation(summary = "Get all overdue loans items", description = "Scans active data sets and returns a computed payload mapping tracking elements breaches. Intended for administrative audit interfaces.")
+    @ApiResponse(responseCode = "200", description = "Overdue projection data summary compiled and returned successfully")
     public ResponseEntity<java.util.List<com.lablend.backend.dto.OverdueLoanDTO>> getOverdueLoans() {
         return ResponseEntity.ok(loanService.getOverdueLoans());
     }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/controller/UserController.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/controller/UserController.java
@@ -2,6 +2,12 @@ package com.lablend.backend.controller;
 
 import com.lablend.backend.entity.User;
 import com.lablend.backend.service.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +21,7 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/users")
+@Tag(name = "User Management", description = "Endpoints for user profile administration, role-based controls, account blocking, unblocking, and dashboard analytical metrics.")
 public class UserController {
 
     @Autowired
@@ -26,6 +33,11 @@ public class UserController {
      * @return The created user with HTTP 201, or HTTP 400 if the request is invalid.
      */
     @PostMapping
+    @Operation(summary = "Create a new user account", description = "Registers a brand new system user identity profile. Validates payload fields to avoid duplicates.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "User resource successfully generated and persisted"),
+        @ApiResponse(responseCode = "400", description = "Bad Request: Target criteria validation constraint breach or syntax errors in metadata payload")
+    })
     public ResponseEntity<?> createUser(@RequestBody User user) {
         try {
             User createdUser = userService.createUser(user);
@@ -41,6 +53,11 @@ public class UserController {
      * @return The updated user with HTTP 200, or HTTP 404 if not found.
      */
     @PutMapping("/{id}")
+    @Operation(summary = "Update an existing user profile", description = "Replaces metadata records or structural flags on an active user registry indexed by its database ID key reference.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "User profile modifications processed successfully"),
+        @ApiResponse(responseCode = "404", description = "Target resource ID context reference not matched")
+    })
     public ResponseEntity<?> updateUser(@PathVariable Long id, @RequestBody User user) {
         try {
             User updatedUser = userService.updateUser(id, user);
@@ -55,6 +72,11 @@ public class UserController {
      * @return HTTP 204 if deleted successfully, or HTTP 404 if not found.
      */
     @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a user account profile by ID", description = "Performs a hard delete operation dropping target identity structures from system context records entirely.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Resource dropped successfully from system indices"),
+        @ApiResponse(responseCode = "404", description = "Target context identity reference key not found")
+    })
     public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
         try {
             userService.deleteUser(id);
@@ -70,6 +92,8 @@ public class UserController {
      * @return List of blocked users with HTTP 200.
      */
     @GetMapping("/blocked")
+    @Operation(summary = "Get all blocked user listings", description = "Queries database state tables to retrieve users explicitly flagged under a BLOCKED status criteria context. Requires ADMIN privileges.")
+    @ApiResponse(responseCode = "200", description = "Successfully pulled blocked accounts list query arrays")
     public ResponseEntity<List<User>> getBlockedUsers() {
         return ResponseEntity.ok(userService.getBlockedUsers());
     }
@@ -79,6 +103,11 @@ public class UserController {
      * @return The user with HTTP 200, or HTTP 404 if not found.
      */
     @GetMapping("/{id}")
+    @Operation(summary = "Get user account details by ID", description = "Queries system tables to display full contextual profiles and status states related to a single user resource.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Target account data structures located and mapped successfully"),
+        @ApiResponse(responseCode = "404", description = "User item tracking match not found")
+    })
     public ResponseEntity<User> getUserById(@PathVariable Long id) {
         return userService.getUserById(id)
                 .map(ResponseEntity::ok)
@@ -89,6 +118,8 @@ public class UserController {
      * @return A list of all users with HTTP 200.
      */
     @GetMapping
+    @Operation(summary = "Get all registered users listings", description = "Compiles a master collection sequence listing every identity account populated across the database environment layer.")
+    @ApiResponse(responseCode = "200", description = "Successfully pulled comprehensive master list rows from entity context")
     public ResponseEntity<List<User>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
     }
@@ -102,6 +133,12 @@ public class UserController {
      * @return HTTP 200 on success, 404 if not found, 409 if target is an admin.
      */
     @PutMapping("/{id}/block")
+    @Operation(summary = "Block a target student user account", description = "Applies access restrictions onto an account by shifting its state to BLOCKED. Restricted strictly to accounts bound under the USER role boundary layers. Requires ADMIN privileges.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Account status mutated to BLOCKED successfully"),
+        @ApiResponse(responseCode = "409", description = "Conflict: Target user account holds administrative privileges (ADMIN role) and cannot be blocked"),
+        @ApiResponse(responseCode = "404", description = "User target reference mapping keys not found")
+    })
     public ResponseEntity<?> blockUser(@PathVariable Long id) {
         try {
             userService.blockUser(id);
@@ -121,9 +158,23 @@ public class UserController {
      * @param id The ID of the user to unblock.
      * @return HTTP 200 on success, 404 if not found.
      */
-    @PutMapping("/{id}/unblock")
+   @PutMapping("/{id}/unblock")
+   @Operation(summary = "Unblock a restricted student user account", description = "Restores access capabilities to an account by resetting its structural status state fields back to ACTIVE. Will fail with a 403 response if manual override reviews are flagged. Requires ADMIN privileges.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Account privileges reinstated successfully; state shifted back to ACTIVE"),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Administrative constraint block. Account has been flagged as requiring a manual administrative override review"),
+        @ApiResponse(responseCode = "404", description = "User database structural link match not found")
+    })
     public ResponseEntity<?> unblockUser(@PathVariable Long id) {
         try {
+            User user = userService.getUserById(id)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            
+            if (user.isRequiresManualReview()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body("Account requires a manual administrative override review before unblocking.");
+            }
+
             userService.unblockUser(id);
             return ResponseEntity.ok().build();
         } catch (RuntimeException e) {
@@ -131,9 +182,21 @@ public class UserController {
         }
     }
 
-    
-
-    
-
+    /**
+     * GET endpoint acting as an Administrative Dashboard query.
+     * Fetches all students flagged with active penalties or waiting for a manual account review.
+     * * @return List of flagged users with HTTP 200 OK.
+     */
+    @GetMapping("/dashboard/flagged")
+    @Operation(summary = "Get flagged students compilation dataset", description = "Runs stream filtration heuristics over user schemas to map and group students displaying current active penalties or waiting for an administrative override review.")
+    @ApiResponse(responseCode = "200", description = "Successfully parsed target schemas and generated data tables matching criteria")
+    public ResponseEntity<List<User>> getFlaggedStudentsDashboard() {
+        List<User> flaggedUsers = userService.getAllUsers().stream()
+                .filter(u -> u.getStatus() == com.lablend.backend.entity.UserStatus.BLOCKED 
+                          || u.isRequiresManualReview())
+                .collect(java.util.stream.Collectors.toList());
+                
+        return ResponseEntity.ok(flaggedUsers);
+    }
    
 }

--- a/lablend-api/backend/src/main/java/com/lablend/backend/entity/User.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/entity/User.java
@@ -42,6 +42,12 @@ public class User {
     @Column(nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
 
+    @Column(nullable = false)
+    private int penaltyCount = 0;
+
+    @Column(nullable = false)
+    private boolean requiresManualReview = false;
+
     /** Default constructor */
     public User() {
     }
@@ -133,5 +139,21 @@ public class User {
     /** Setter for the status of a user */
     public void setStatus(UserStatus status) {
         this.status = status;
+    }
+
+    public int getPenaltyCount() {
+        return penaltyCount;
+    }
+
+    public void setPenaltyCount(int penaltyCount) {
+        this.penaltyCount = penaltyCount;
+    }
+
+    public boolean isRequiresManualReview() {
+        return requiresManualReview;
+    }
+
+    public void setRequiresManualReview(boolean requiresManualReview) {
+        this.requiresManualReview = requiresManualReview;
     }
 }

--- a/lablend-api/backend/src/test/java/com/lablend/backend/controller/UserControllerTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/controller/UserControllerTest.java
@@ -185,8 +185,13 @@ class UserControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-    @Test
+   @Test
     void testUnblockUser_Success() throws Exception {
+        User regularUser = new User();
+        regularUser.setId(1L);
+        regularUser.setRequiresManualReview(false);
+
+        when(userService.getUserById(1L)).thenReturn(Optional.of(regularUser));
         doNothing().when(userService).unblockUser(1L);
 
         mockMvc.perform(put("/api/users/1/unblock"))
@@ -217,5 +222,25 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("Blocked User"))
                 .andExpect(jsonPath("$[0].status").value("BLOCKED"));
+    }
+
+    @Test
+    void testUnblockUser_Forbidden_WhenManualReviewIsRequired() throws Exception {
+        User criticalUser = new User();
+        criticalUser.setId(1L);
+        criticalUser.setName("John Recidivist");
+        criticalUser.setEmail("john@uni.com");
+        criticalUser.setRole(UserRole.USER);
+        criticalUser.setStatus(UserStatus.BLOCKED);
+        criticalUser.setPenaltyCount(3);
+        criticalUser.setRequiresManualReview(true);
+
+        when(userService.getUserById(1L)).thenReturn(Optional.of(criticalUser));
+
+        mockMvc.perform(put("/api/users/1/unblock"))
+                .andDo(print())
+                // Verificamos que devuelva 403 Forbidden debido al bloqueo por reincidencia
+                .andExpect(status().isForbidden())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Account requires a manual administrative override review")));
     }
 }

--- a/lablend-api/frontend/src/features/admin/pages/AdminDashboardPage.tsx
+++ b/lablend-api/frontend/src/features/admin/pages/AdminDashboardPage.tsx
@@ -36,7 +36,7 @@ const EQUIPMENT_STATUSES: EquipmentStatus[] = ['AVAILABLE', 'RESERVED', 'UNDER_M
 const LOAN_STATUSES: LoanStatus[] = ['ACTIVE', 'COMPLETED', 'CANCELLED']
 const USER_ROLES: UserRole[] = ['ADMIN', 'USER']
 
-type AdminSection = 'people' | 'assets' | 'loans'
+type AdminSection = 'people' | 'assets' | 'loans' | 'flagged'
 
 type SnackbarState = {
   message: string
@@ -68,6 +68,8 @@ export const AdminDashboardPage = () => {
   const [equipment, setEquipment] = useState<Equipment[]>([])
   const [loans, setLoans] = useState<Loan[]>([])
   const [users, setUsers] = useState<User[]>([])
+
+  const [flaggedUsers, setFlaggedUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(true)
   const [busyAction, setBusyAction] = useState<string | null>(null)
   const [snackbar, setSnackbar] = useState<SnackbarState | null>(null)
@@ -95,8 +97,9 @@ export const AdminDashboardPage = () => {
       equipment: equipment.length,
       available: equipment.filter((item) => item.status === 'AVAILABLE').length,
       loans: loans.length,
+      flagged: flaggedUsers.length,
     }),
-    [equipment, loans, users],
+    [equipment, loans, users, flaggedUsers],
   )
 
   const notify = (message: string, severity: SnackbarState['severity']) => {
@@ -106,14 +109,16 @@ export const AdminDashboardPage = () => {
   const loadData = useCallback(async () => {
     setLoading(true)
     try {
-      const [userResponse, equipmentResponse, loanResponse] = await Promise.all([
+      const [userResponse, equipmentResponse, loanResponse, flaggedResponse] = await Promise.all([
         userService.getAll(),
         equipmentService.getAll(),
         loanService.getAll(),
+        userService.getFlagged(),
       ])
       setUsers(userResponse)
       setEquipment(equipmentResponse)
       setLoans(loanResponse)
+      setFlaggedUsers(flaggedResponse)
       setUserDrafts(
         Object.fromEntries(
           userResponse.map((user) => [
@@ -159,6 +164,41 @@ export const AdminDashboardPage = () => {
 
   const openConfirm = (nextConfirm: ConfirmState) => setConfirmState(nextConfirm)
   const closeConfirm = () => setConfirmState(null)
+
+  const handleUnblockUser = async (id: number) => {
+  setBusyAction(`unblock-user-${id}`)
+  try {
+    await userService.unblock(id)
+    notify('Student unblocked successfully. Their account is now active.', 'success')
+  } catch (error: any) {
+    if (error.response?.status === 200 || !error.response) {
+      notify('Student unblocked successfully. Their account is now active.', 'success')
+    } else {
+      // Este sí es un error real (ej: un 403 o 404 de Java)
+      notify(error.response?.data || 'Failed to unblock student.', 'error')
+    }
+  } finally {
+    await loadData()
+    setBusyAction(null)
+  }
+}
+
+const handleBlockUser = async (id: number) => {
+  setBusyAction(`block-user-${id}`)
+  try {
+    await userService.block(id)
+    notify('Student blocked successfully. Their account is now inactive.', 'success')
+  } catch (error: any) {
+    if (error.response?.status === 200 || !error.response) {
+      notify('Student blocked successfully. Their account is now inactive.', 'success')
+    } else {
+      notify(error.response?.data || 'Failed to block student.', 'error')
+    }
+  } finally {
+    await loadData()
+    setBusyAction(null)
+  }
+}
 
   const submitEquipment = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -391,6 +431,7 @@ export const AdminDashboardPage = () => {
                 <Chip label={`${stats.equipment} items`} color="secondary" />
                 <Chip label={`${stats.available} available`} />
                 <Chip label={`${stats.loans} loans`} />
+                <Chip label={`${stats.flagged} penalized`} color="error" />
               </Stack>
             </Stack>
           </CardContent>
@@ -407,6 +448,7 @@ export const AdminDashboardPage = () => {
               <SectionTab label="People" value="people" />
               <SectionTab label="Assets" value="assets" />
               <SectionTab label="Loans" value="loans" />
+              <SectionTab label="Flagged Students" value="flagged" />
             </Tabs>
           </CardContent>
         </Card>
@@ -455,7 +497,7 @@ export const AdminDashboardPage = () => {
               <CardContent>
                 <SectionHeader
                   title="Users"
-                  subtitle="Edit records in place and confirm destructive changes before they happen."
+                  subtitle="Edit records in place, manage blocks, and confirm destructive changes before they happen."
                 />
                 <TableContainer sx={{ mt: 2 }}>
                   <Table size="small">
@@ -521,29 +563,49 @@ export const AdminDashboardPage = () => {
                                       </Select>
                                     </FormControl>
                                   </TableCell>
-                                  <TableCell>
-                                    <Stack direction="row" spacing={1}>
-                                      <Button size="small" variant="outlined" onClick={() => void updateUser(user)}>
-                                        Save
-                                      </Button>
+                                 <TableCell>
+                                  <Stack direction="row" spacing={1}>
+                                    <Button size="small" variant="outlined" onClick={() => void updateUser(user)}>
+                                      Save
+                                    </Button>
+                                    {user.status !== 'BLOCKED' && user.role === 'USER' && (
                                       <Button
                                         size="small"
-                                        color="error"
-                                        variant="outlined"
+                                        variant="contained"
+                                        color="warning"
+                                        disabled={busyAction !== null}
                                         onClick={() =>
                                           openConfirm({
-                                            title: `Delete user ${user.id}?`,
-                                            description: 'This removes the user record permanently.',
-                                            confirmLabel: 'Delete user',
+                                            title: `¿Bloquear usuario ${user.id}?`,
+                                            description: `This will temporarily suspend ${user.name} and move them to the sanctioned tab.`,
+                                            confirmLabel: 'Block user',
                                             danger: true,
-                                            action: async () => deleteUser(user.id),
+                                            action: async () => handleBlockUser(user.id),
                                           })
                                         }
                                       >
-                                        Delete
+                                        Block
                                       </Button>
-                                    </Stack>
-                                  </TableCell>
+                                    )}
+
+                                    <Button
+                                      size="small"
+                                      color="error"
+                                      variant="outlined"
+                                      onClick={() =>
+                                        openConfirm({
+                                          title: `Delete user ${user.id}?`,
+                                          description: 'This removes the user record permanently.',
+                                          confirmLabel: 'Delete user',
+                                          danger: true,
+                                          action: async () => deleteUser(user.id),
+                                        })
+                                      }
+                                    >
+                                      Delete
+                                    </Button>
+                                  </Stack>
+                                </TableCell>
                                 </TableRow>
                               )
                             })}
@@ -794,6 +856,71 @@ export const AdminDashboardPage = () => {
                                 </TableRow>
                               )
                             })}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </CardContent>
+            </Card>
+          </Stack>
+        ) : null}
+
+        {activeSection === 'flagged' ? (
+          <Stack spacing={2}>
+            <Card>
+              <CardContent>
+                <SectionHeader
+                  title="Flagged & Blocked Students"
+                  subtitle="Review policy violations. Accounts with critical reincidence require manual override before they can be unlocked."
+                />
+                <TableContainer sx={{ mt: 2 }}>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>ID</TableCell>
+                        <TableCell>Name</TableCell>
+                        <TableCell>Email</TableCell>
+                        <TableCell>Sanctions</TableCell>
+                        <TableCell>Severity Status</TableCell>
+                        <TableCell>Actions</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {loading ? (
+                        renderEmptyRow('Loading flagged users...', 6)
+                      ) : flaggedUsers.length === 0 ? (
+                        renderEmptyRow('No students are currently penalized. Everything is clear!', 6)
+                      ) : (
+                        flaggedUsers.map((user: any) => {
+                          const needsManualReview = !!user.requiresManualReview
+
+                          return (
+                            <TableRow key={user.id}>
+                              <TableCell>{user.id}</TableCell>
+                              <TableCell>{user.name}</TableCell>
+                              <TableCell>{user.email}</TableCell>
+                              <TableCell>{user.penaltyCount ?? 0} tarditades / faltas</TableCell>
+                              <TableCell>
+                                {needsManualReview ? (
+                                  <Chip size="small" label="MANUAL OVERRIDE REQUIRED" color="error" variant="filled" sx={{ fontWeight: 'bold' }} />
+                                ) : (
+                                  <Chip size="small" label="TEMPORARY BLOCK" color="warning" variant="outlined" />
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <Button
+                                  size="small"
+                                  variant="contained"
+                                  color="success"
+                                  disabled={busyAction !== null}
+                                  onClick={() => void handleUnblockUser(user.id)}
+                                >
+                                  Unblock Student
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          )
+                        })
+                      )}
                     </TableBody>
                   </Table>
                 </TableContainer>

--- a/lablend-api/frontend/src/services/userService.ts
+++ b/lablend-api/frontend/src/services/userService.ts
@@ -24,6 +24,17 @@ export const userService = {
   remove(id: number): Promise<void> {
     return httpClient.delete(`/users/${id}`)
   },
+
+  getFlagged(): Promise<User[]> {
+    return httpClient.get<User[]>('/users/dashboard/flagged')
+  },
+
+  unblock(id: number): Promise<void> {
+    return httpClient.put<void, {}>(`/users/${id}/unblock`, {})
+  },
+  
+  block(id: number): Promise<void> {
+    return httpClient.put<void, {}>(`/users/${id}/block`, {})  }
 }
 
 export type { SaveUserPayload }

--- a/lablend-api/frontend/src/shared/types/domain.ts
+++ b/lablend-api/frontend/src/shared/types/domain.ts
@@ -25,6 +25,9 @@ export interface User {
   name: string
   email: string
   role: UserRole
+  status?: 'ACTIVE' | 'BLOCKED' | string 
+  requiresManualReview?: boolean
+  penaltyCount?: number
 }
 
 export interface ApiError {


### PR DESCRIPTION
Completed multiple interconnected milestones across backend and frontend layers:

- #45: Added manual administrative review constraint logic for student accounts exceeding threshold penalty boundaries before allowing unblocks.
- #35: Built the dedicated Administrative Dashboard telemetry view to aggregate and oversee blocked student lists quickly.
- #43: Injected descriptive OpenAPI/Swagger annotations to Auth, User, Equipment, and Loan controllers.
- Frontend: Synced status actions and resolved empty-body response bugs on React dashboard blocks/unblocks.