### PR TITLE
Improve loan return validation and security restrictions

### DIFF
--- a/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
+++ b/lablend-api/backend/src/main/java/com/lablend/backend/service/impl/LoanServiceImpl.java
@@ -126,6 +126,10 @@ public class LoanServiceImpl implements LoanService {
         Loan loan = loanRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Loan not found with id: " + id));
 
+        if (loan.getStatus() != LoanStatus.ACTIVE) {
+            throw new IllegalStateException("Loan is already completed or cancelled");
+        }
+
         loan.setStatus(LoanStatus.COMPLETED);
 
         updateEquipmentStatus(loan.getEquipmentId(), EquipmentStatus.AVAILABLE);

--- a/lablend-api/backend/src/test/java/com/lablend/backend/controller/SecurityRestrictionsTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/controller/SecurityRestrictionsTest.java
@@ -1,0 +1,44 @@
+package com.lablend.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SecurityRestrictionsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void accessLoans_WithoutToken_ShouldBeForbidden() throws Exception {
+        mockMvc.perform(get("/api/loans"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void accessUsers_WithoutToken_ShouldBeForbidden() throws Exception {
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void blockUser_WithoutToken_ShouldBeForbidden() throws Exception {
+        mockMvc.perform(put("/api/users/1/block"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteUser_WithoutToken_ShouldBeForbidden() throws Exception {
+        mockMvc.perform(delete("/api/users/1"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
+++ b/lablend-api/backend/src/test/java/com/lablend/backend/service/LoanServiceImplTest.java
@@ -364,4 +364,38 @@ class LoanServiceImplTest {
         verify(loanRepository, never()).save(any(Loan.class));
         verify(equipmentRepository, never()).findById(any());
     }
+
+@Test
+    void returnLoan_WhenAlreadyCompleted_ShouldThrowException() {
+        Loan loan = new Loan();
+        loan.setId(1L);
+        loan.setEquipmentId(10L);
+        loan.setStatus(LoanStatus.COMPLETED);
+
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            loanService.returnLoan(1L);
+        });
+
+        assertTrue(exception.getMessage().contains("already completed"));
+        verify(loanRepository, never()).save(any(Loan.class));
+    }
+
+    @Test
+    void returnLoan_WhenCancelled_ShouldThrowException() {
+        Loan loan = new Loan();
+        loan.setId(1L);
+        loan.setEquipmentId(10L);
+        loan.setStatus(LoanStatus.CANCELLED);
+
+        when(loanRepository.findById(1L)).thenReturn(Optional.of(loan));
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            loanService.returnLoan(1L);
+        });
+
+        assertTrue(exception.getMessage().contains("already completed"));
+        verify(loanRepository, never()).save(any(Loan.class));
+    }
 }


### PR DESCRIPTION
- Added validation to prevent returning already completed or cancelled loans
- Added unit tests for returnLoan validation cases
- Added security tests to verify protected endpoints reject unauthenticated access